### PR TITLE
Removed L-R Padding for cards on mobile

### DIFF
--- a/my/src/components/Card.vue
+++ b/my/src/components/Card.vue
@@ -429,6 +429,8 @@ export default Vue.extend({
     font-weight: 300;
     color: white;
     /* margin: 20px 20px 50px 20px; */
+    margin:0;
+    padding: 50px 0 50px 0;
   }
   .field {
     margin: 40px auto;


### PR DESCRIPTION
Had to do it to center it for mobile

Before:
![image](https://user-images.githubusercontent.com/28623347/67167606-02c41a80-f36a-11e9-894e-9e7c3dd3a434.png)

After:
![image](https://user-images.githubusercontent.com/28623347/67167611-0eafdc80-f36a-11e9-862b-4e1c8dacd4ac.png)
