### PR TITLE
Change color of checkbox error message to be easier to see

### DIFF
--- a/my/src/components/Checkbox.vue
+++ b/my/src/components/Checkbox.vue
@@ -35,6 +35,11 @@ export default Vue.extend({
   caret-color: #1976d2 !important;
 }
 
+.container >>> .error--text {
+  caret-color: #bb2e35d8 !important;
+  color: #bb2e35d8 !important;
+}
+
 .container >>> .v-input--selection-controls__input {
   margin-right: 25px;
 }


### PR DESCRIPTION
The color for checkbox error messages was different than the error message color used for cards.