### PR TITLE
Fix bug where radio button selections were not registered on MS Edge.

### DIFF
--- a/my/src/components/Card.vue
+++ b/my/src/components/Card.vue
@@ -61,7 +61,7 @@
             :id="data"
             :value="data"
             :checked="value === data"
-            @input="onChange($event.target.value)"
+            @change="onChange($event.target.value)"
             color="#000000"
             class="montserratify"
           />


### PR DESCRIPTION
It seems that browsers recognized that different handlers (click, change, select, etc.) were largely equivalent on the same element, but MS Edge doesn't seem to treat @input as a legitimate handler for radio buttons.

Changed @input to @change per https://vuejs.org/v2/guide/forms.html.

Tested on Chrome and Firefox as well.