### PR TITLE
Add /admin application filters

### DIFF
--- a/admin/src/components/ApplicantDropdown.vue
+++ b/admin/src/components/ApplicantDropdown.vue
@@ -210,7 +210,7 @@ import { firestore, auth } from 'firebase';
 
 export default Vue.extend({
   name: 'Applicant',
-  props: ['usrname', 'applicant', 'isReviewed', 'refetchCurrentPage'],
+  props: ['usrname', 'applicant', 'isReviewed'],
   data: () => ({
     dialog: false,
     currentPage: 0,

--- a/admin/src/components/DataTable.vue
+++ b/admin/src/components/DataTable.vue
@@ -16,7 +16,7 @@
         </v-list>
       </v-menu>
       <v-spacer></v-spacer>
-      <v-text-field v-model="search" append-icon="search" label="Search" single-line hide-details></v-text-field>
+      <v-text-field v-model="search" append-icon="search" label="Search" single-line hide-details @input="bruh()"></v-text-field>
     </v-card-title>
     <v-data-table
       v-bind:peeps="peeps"
@@ -28,6 +28,7 @@
       hide-actions
       :pagination.sync="pagination"
       item-key="contact.email"
+      ref="tableref"
     >
       <template slot="items" slot-scope="props">
         <tr @click="selectRow($event, props)">
@@ -274,6 +275,11 @@ export default Vue.extend({
         .doc('statistics')
         .get();
       this.numApplicants = Math.ceil(stats.data()!.applications / this.rowsPerPage);
+    },
+    bruh() {
+      setTimeout(() => {
+        this.numApplicants = this.pagination.rowsPerPage ? Math.ceil(this.pagination.totalItems / this.pagination.rowsPerPage) : 0;
+      }, 10);
     },
   },
   async mounted() {

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -2948,10 +2948,6 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.0.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
 core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
@@ -3776,18 +3772,6 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es6-promise-promise@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promise-promise/-/es6-promise-promise-1.0.0.tgz#3a91f235fdd2b08c4492b5734dfd1f417289b994"
-  integrity sha1-OpHyNf3SsIxEkrVzTf0fQXKJuZQ=
-  dependencies:
-    es6-promise "^3.2.1"
-
-es6-promise@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
-  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
 
 es6-promise@^4.0.3:
   version "4.2.8"


### PR DESCRIPTION
DB filtering for applications
->Made Firebase indexes for relevant properties
->Removed refetchcurrent for time being
->Fixed some types
->Current categories are ('All Applications','Assigned to Me','Accepted Applicants','Rejected Applicants')

Getting the filtered set size for anything other than all applicants rn requires getting the whole data set, which counters the point of server side pagination -> TODO: track stats for filtered categories (accepted, rejected) so size is always known