### PR TITLE
Add assigned to me not marked filter

### DIFF
--- a/admin/src/components/DataTable.vue
+++ b/admin/src/components/DataTable.vue
@@ -127,6 +127,7 @@ export default Vue.extend({
       items: [
         'All Applicants',
         'Assigned to Me',
+        'Assigned to Me - Not Marked',
         'Accepted Applicants',
         'Rejected Applicants',
         '1/3',
@@ -187,6 +188,14 @@ export default Vue.extend({
             auth().currentUser!.email as string,
           ];
           this.changeScope([]);
+          break;
+        case 'Assigned to Me - Not Marked':
+          this.restriction = [
+            '_.reviews.assignedTo',
+            'array-contains',
+            auth().currentUser!.email as string,
+          ];
+          this.changeScope(['Assigned to Me - Not Marked']);
           break;
         case 'Accepted Applicants':
           this.restriction = ['_.decision', '==', 'accepted'];
@@ -253,6 +262,9 @@ export default Vue.extend({
       if (customFilter.includes('1/3') || customFilter.includes('2/3')) {
         const filter = customFilter.includes('1/3') ? 1 : 2;
         resultsToUse = resultsToUse.filter(each => each._.reviews.scores.length === filter);
+      }
+      else if (customFilter.includes('Assigned to Me - Not Marked')) {
+        resultsToUse = resultsToUse.filter(each => !each._.reviews.scores.map(adminReviews => adminReviews.reviewer).includes(auth().currentUser!.email as string));
       }
       this.numApplicants = Math.ceil(resultsToUse.length / this.rowsPerPage);
       this.pagination.totalItems = this.numApplicants;


### PR DESCRIPTION
In admin, there should now be an option to filter applications by ones that are assigned to you to judge, but you have not marked.

- I'm assuming this is how an application on firebase will look if you have not yet marked the application. In this case, the following application will show up if you filter by `not marked - assigned to me`:

![Screen Shot 2021-09-24 at 7 27 51 PM](https://user-images.githubusercontent.com/23485601/134752137-0f838c79-f2e8-4a86-95f1-238815d924b3.png)

![Screen Shot 2021-09-24 at 8 51 47 PM](https://user-images.githubusercontent.com/23485601/134752354-5e2ebdf9-96d8-4641-9911-bab40efd7b5e.png)

- A marked application would look like this, in which case this application will not show up if you filter by `assigned to me - not marked`:

![Screen Shot 2021-09-24 at 7 30 55 PM](https://user-images.githubusercontent.com/23485601/134752236-f7744c86-6cdb-4e88-9dd9-029634ab8b15.png)

